### PR TITLE
socket.io version and example js

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ API tools and documentation
 ## Socket API
     http://socket.coincap.io
 
-To connect to CoinCap WebSockets you must use socket.io-client 0.9.16 or another
-WebSocket client compatiable with that version of Socket.io
-You can find the 0.9.16 client on github
-[https://github.com/automattic/socket.io-client/tree/0.9](https://github.com/automattic/socket.io-client/tree/0.9)
-
 [Sample code attached](https://github.com/CoinCapDev/CoinCap/blob/master/subscribe.js)
 
 ### responses

--- a/subscribe.js
+++ b/subscribe.js
@@ -3,7 +3,7 @@
 <script type="text/javascript">
     var socket = io.connect('http://socket.coincap.io');
 
-    socket.on('trade', function (tradeMsg) {
+    socket.on('trades', function (tradeMsg) {
         console.log(tradeMsg);
     })
 


### PR DESCRIPTION
Just wanted to note that if you use 0.9.16 you get:
root@ubuntu:/var/www# nodejs coincap.js
{"code":0,"message":"Transport unknown"}

It works fine though if you use a current version of socket.io-client.

Also the word is trades not trade.  I was lost as to why it wasn't working but I looked on http://coincap.io and the channel was trades and then voila.  Hopefully this will save someone some time.
